### PR TITLE
Adjust game for full-screen WebView

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -1,3 +1,11 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
 body {
     -moz-user-select: none;
     -webkit-user-select: none;

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-        <meta name="viewport" content="user-scalable=no">
+        <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
         <link rel="icon" href="icon/icon.png" type="image/png">
         <link rel="apple-touch-icon" href="icon/icon.png">
         <link rel="stylesheet" type="text/css" href="css/game.css">

--- a/js/rmmz_core.js
+++ b/js/rmmz_core.js
@@ -841,10 +841,7 @@ Graphics._stretchWidth = function() {
 
 Graphics._stretchHeight = function() {
     if (Utils.isMobileDevice()) {
-        // [Note] Mobile browsers often have special operations at the top and
-        //   bottom of the screen.
-        const rate = Utils.isLocal() ? 1.0 : 0.9;
-        return document.documentElement.clientHeight * rate;
+        return document.documentElement.clientHeight;
     } else {
         return window.innerHeight;
     }


### PR DESCRIPTION
## Summary
- make the game canvas use the entire Android screen in WebView
- ensure HTML and CSS expand to full screen and prevent scrolling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8c2d018ec833295bb9f3ca49be3a1