### PR TITLE
Add mobile landscape fullscreen toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
         <title>닭농장 키우기</title>
     </head>
     <body style="background-color: black">
+        <button id="fullscreenBtn" style="position:absolute;top:10px;right:10px;z-index:999;">전체화면</button>
+        <script src="js/fullscreen.js"></script>
         <script type="text/javascript" src="js/main.js"></script>
     </body>
 </html>

--- a/js/fullscreen.js
+++ b/js/fullscreen.js
@@ -1,0 +1,35 @@
+function adjustGameSize() {
+    if (window.Graphics && Graphics.resize) {
+        Graphics.resize(window.innerWidth, window.innerHeight);
+    }
+}
+
+async function enterFullscreen() {
+    const elem = document.documentElement;
+    if (elem.requestFullscreen) {
+        await elem.requestFullscreen({ navigationUI: "hide" });
+    } else if (elem.webkitRequestFullscreen) {
+        await elem.webkitRequestFullscreen();
+    } else if (elem.msRequestFullscreen) {
+        await elem.msRequestFullscreen();
+    }
+
+    if (screen.orientation && screen.orientation.lock) {
+        try {
+            await screen.orientation.lock("landscape");
+        } catch (e) {
+            // Ignore errors
+        }
+    }
+
+    adjustGameSize();
+    setTimeout(() => window.scrollTo(0, 1), 0);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const btn = document.getElementById("fullscreenBtn");
+    if (btn) {
+        btn.addEventListener("click", enterFullscreen);
+    }
+    window.addEventListener("resize", adjustGameSize);
+});


### PR DESCRIPTION
## Summary
- add fullscreen button for mobile landscape mode
- lock orientation, hide address bar and resize game to screen

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a8cd735cf48332a96f7af77a004dbb